### PR TITLE
Add more unit tests and automatic testing via GitHub Actions

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  # run on every push to main
+  push:
+    branches:
+    - main
+  # run on every push (not commit) to a PR, plus open/reopen
+  pull_request:
+    types:
+    - synchronize
+    - opened
+    - reopened
+
+jobs:
+  linux-test:
+    name: ${{ matrix.os }} / test / Python ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      # continue testing other configurations even if a matrix job fails
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest"]
+        python-version: ["3.11"]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Run tests
+      if: always()
+      run: pytest .

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -31,6 +31,8 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
+    - run: pip install pytest
+
     - name: Run tests
       if: always()
       run: pytest .

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -1,38 +1,35 @@
-name: CI
+# This is a GitHub Actions workflow file which instructs GitHub what commands to
+# run on a "fresh" machine (a cloud-provisioned worker) and when (e.g. when a
+# branch is updated).
+
+name: pytest
 
 on:
-  # run on every push to main
+  # execute this workflow on every push to main
   push:
     branches:
     - main
-  # run on every push (not commit) to a PR, plus open/reopen
+  # also execute this workflow on every push to any PR
   pull_request:
     types:
     - synchronize
-    - opened
-    - reopened
 
 jobs:
   linux-test:
-    name: ${{ matrix.os }} / test / Python ${{ matrix.python-version }}
-    runs-on: ${{ matrix.os }}
+    name: Ubuntu / test
+    runs-on: ubuntu-latest
 
-    strategy:
-      # continue testing other configurations even if a matrix job fails
-      fail-fast: false
-      matrix:
-        os: ["ubuntu-latest"]
-        python-version: ["3.11"]
-
+    # run the following steps in order
+    # if any step fails, the workflow halts and fails
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Checkout Git repo and change directory
+      uses: actions/checkout@v3
+
+    - name: Install Python
       uses: actions/setup-python@v4
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: 3.11
 
     - run: pip install pytest
 
-    - name: Run tests
-      if: always()
-      run: pytest .
+    - run: pytest .

--- a/rpn-calc/src/tests/test_calculate.py
+++ b/rpn-calc/src/tests/test_calculate.py
@@ -9,3 +9,8 @@ def test_sum():
 def test_prod():
     commands = ['3.0', '2.0', '*']
     assert main(commands) == 6.0
+
+
+def test_subtract():
+    commands = ['2.0', '1.0', '-']
+    assert main(commands) == 1.0

--- a/rpn-calc/src/tests/test_calculate.py
+++ b/rpn-calc/src/tests/test_calculate.py
@@ -13,4 +13,4 @@ def test_prod():
 
 def test_subtract():
     commands = ['2.0', '1.0', '-']
-    assert main(commands) == 1.0
+    assert main(commands) == -1.0


### PR DESCRIPTION
I added another simple pytest unit test for subtraction, and configured a workflow to automatically run those tests using GitHub Actions. (GitHub runs pytest for us every time we make a change, and puts the logs at the bottom of PRs.) But the tests are failing. I haven't looked into it yet.

META: First thing we tackle. Starts failing a test.
TODO: commit messages are silly mode